### PR TITLE
Support runtime versions

### DIFF
--- a/src/main/java/io/openshift/booster/catalog/Booster.java
+++ b/src/main/java/io/openshift/booster/catalog/Booster.java
@@ -23,6 +23,7 @@ public class Booster
    private String id;
    private String githubRepo;
    private String gitRef;
+   private String buildProfile;
    private String description = "No description available";
    private String boosterDescriptorPath = ".openshiftio/booster.yaml";
    private Mission mission;
@@ -76,6 +77,14 @@ public class Booster
    }
 
    /**
+    * @return the buildProfile
+    */
+   public String getBuildProfile()
+   {
+      return buildProfile;
+   }
+
+   /**
     * @return the boosterDescriptorPath
     */
    @Transient
@@ -106,6 +115,14 @@ public class Booster
    public void setGitRef(String gitRef)
    {
       this.gitRef = gitRef;
+   }
+
+   /**
+    * @param buildProfile the buildProfile to set
+    */
+   public void setBuildProfile(String buildProfile)
+   {
+      this.buildProfile = buildProfile;
    }
 
    /**
@@ -210,6 +227,7 @@ public class Booster
    {
       final int prime = 31;
       int result = 1;
+      result = prime * result + ((buildProfile == null) ? 0 : buildProfile.hashCode());
       result = prime * result + ((gitRef == null) ? 0 : gitRef.hashCode());
       result = prime * result + ((githubRepo == null) ? 0 : githubRepo.hashCode());
       result = prime * result + ((id == null) ? 0 : id.hashCode());
@@ -227,6 +245,13 @@ public class Booster
       if (getClass() != obj.getClass())
          return false;
       Booster other = (Booster) obj;
+      if (buildProfile == null)
+      {
+         if (other.buildProfile != null)
+            return false;
+      }
+      else if (!buildProfile.equals(other.buildProfile))
+         return false;
       if (gitRef == null)
       {
          if (other.gitRef != null)
@@ -261,8 +286,8 @@ public class Booster
    @Override
    public String toString()
    {
-      return "Booster [githubRepo=" + githubRepo + ", gitRef=" + gitRef + ", obsidianDescriptorPath="
-               + boosterDescriptorPath + ", metadata=" + metadata + ", getName()=" + getName() + ", getDescription()="
-               + getDescription() + "]";
+      return "Booster [githubRepo=" + githubRepo + ", gitRef=" + gitRef + ", buildProfile=" + buildProfile
+               + ", obsidianDescriptorPath=" + boosterDescriptorPath + ", metadata=" + metadata + ", getName()="
+               + getName() + ", getDescription()=" + getDescription() + "]";
    }
 }

--- a/src/main/java/io/openshift/booster/catalog/Booster.java
+++ b/src/main/java/io/openshift/booster/catalog/Booster.java
@@ -27,6 +27,7 @@ public class Booster
    private String boosterDescriptorPath = ".openshiftio/booster.yaml";
    private Mission mission;
    private Runtime runtime;
+   private Version version;
 
    private Path contentPath;
 
@@ -153,6 +154,22 @@ public class Booster
    public void setRuntime(Runtime runtime)
    {
       this.runtime = runtime;
+   }
+
+   /**
+    * @return the version
+    */
+   public Version getVersion()
+   {
+      return version;
+   }
+
+   /**
+    * @param version the version to set
+    */
+   public void setVersion(Version version)
+   {
+      this.version = version;
    }
 
    /**

--- a/src/main/java/io/openshift/booster/catalog/Version.java
+++ b/src/main/java/io/openshift/booster/catalog/Version.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.openshift.booster.catalog;
+
+/**
+ *
+ * @author <a href="mailto:tschotan@redhat.com">Tako Schotanus</a>
+ */
+public class Version implements Comparable<Version>
+{
+   private final String id;
+   private final String name;
+
+   public Version(String id)
+   {
+      this.id = id;
+      this.name = id;
+   }
+
+   public Version(String id, String name)
+   {
+      this.id = id;
+      this.name = name;
+   }
+
+   /**
+    * This method is needed so the Web UI can know what's the internal ID used
+    */
+   public String getKey()
+   {
+      return getId();
+   }
+
+   /**
+    * @return the id
+    */
+   public String getId()
+   {
+      return id;
+   }
+
+   /**
+    * @return the name
+    */
+   public String getName()
+   {
+      return name;
+   }
+
+   @Override
+   public int compareTo(Version o)
+   {
+      return getName().compareTo(o.getName());
+   }
+
+   @Override
+   public int hashCode()
+   {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((id == null) ? 0 : id.hashCode());
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      Version other = (Version) obj;
+      if (id == null)
+      {
+         if (other.id != null)
+            return false;
+      }
+      else if (!id.equals(other.id))
+         return false;
+      return true;
+   }
+
+   @Override
+   public String toString()
+   {
+      return "Version [id=" + id + ", name=" + name + "]";
+   }
+}

--- a/src/test/java/io/openshift/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/openshift/booster/catalog/BoosterCatalogServiceTest.java
@@ -16,17 +16,32 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.openshift.booster.catalog.BoosterCatalogService.Builder;
+
 /**
  *
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
 public class BoosterCatalogServiceTest
 {
+    
+   private BoosterCatalogService buildCatalogService() {
+       Builder builder = new BoosterCatalogService.Builder();
+       String repo = System.getenv("LAUNCHPAD_BACKEND_CATALOG_GIT_REPOSITORY");
+       if (repo != null) {
+           builder.catalogRepository(repo);
+       }
+       String ref = System.getenv("LAUNCHPAD_BACKEND_CATALOG_GIT_REF");
+       if (ref != null) {
+           builder.catalogRef(ref);
+       }
+       return builder.build();
+   }
 
    @Test
    public void testProcessMetadata() throws Exception
    {
-      BoosterCatalogService service = new BoosterCatalogService.Builder().build();
+      BoosterCatalogService service = buildCatalogService();
       Path metadataFile = Paths.get(getClass().getResource("metadata.json").toURI());
       Map<String, Mission> missions = new HashMap<>();
       Map<String, Runtime> runtimes = new HashMap<>();
@@ -38,7 +53,7 @@ public class BoosterCatalogServiceTest
    @Test
    public void testIndex() throws Exception
    {
-      BoosterCatalogService service = new BoosterCatalogService.Builder().build();
+      BoosterCatalogService service = buildCatalogService();
       assertThat(service.getBoosters()).isEmpty();
       service.index();
       assertThat(service.getBoosters()).isNotEmpty();


### PR DESCRIPTION
Adds the idea of runtime versions to the `Booster`.
It does this automatically by determining how many folder levels there are between the root of the catalog and the YAML file. If it's 2 then there's only a `Mission` and a `Runtime` and no versions (or actually a single implicit one). If there are 3 folders then the "deepest" folder is used to determine the `Version`s.
There's an extra method to retrieve versions: `getVersions(Mission, Runtime)` as well as a new method  to retrieve a `Booster` given a mission , a runtime and a version: `getBooster(Mission, Runtime, Version)`.