### PR TITLE
fix: makes booster remote configurable

### DIFF
--- a/src/main/java/io/openshift/booster/catalog/spi/NativeGitBoosterCatalogPathProvider.java
+++ b/src/main/java/io/openshift/booster/catalog/spi/NativeGitBoosterCatalogPathProvider.java
@@ -24,7 +24,7 @@ import io.openshift.booster.catalog.Booster;
 public class NativeGitBoosterCatalogPathProvider implements BoosterCatalogPathProvider
 {
    private static final Logger logger = Logger.getLogger(NativeGitBoosterCatalogPathProvider.class.getName());
-   private static final String GITHUB_URL = "https://github.com/";
+   private static final String GITHUB_URL = System.getProperty("BOOSTER_GIT_REMOTE", "https://github.com/");
 
    private final String catalogRepositoryURI;
    private final String catalogRef;

--- a/src/main/java/io/openshift/booster/catalog/spi/NativeGitBoosterCatalogPathProvider.java
+++ b/src/main/java/io/openshift/booster/catalog/spi/NativeGitBoosterCatalogPathProvider.java
@@ -24,7 +24,7 @@ import io.openshift.booster.catalog.Booster;
 public class NativeGitBoosterCatalogPathProvider implements BoosterCatalogPathProvider
 {
    private static final Logger logger = Logger.getLogger(NativeGitBoosterCatalogPathProvider.class.getName());
-   private static final String GITHUB_URL = System.getProperty("BOOSTER_GIT_REMOTE", "https://github.com/");
+   private static final String BOOSTER_CATALOG_GIT_HOST = System.getProperty("BOOSTER_CATALOG_DEFAULT_GIT_HOST", "https://github.com/");
 
    private final String catalogRepositoryURI;
    private final String catalogRef;
@@ -77,7 +77,7 @@ public class NativeGitBoosterCatalogPathProvider implements BoosterCatalogPathPr
       try
       {
          ProcessBuilder builder = new ProcessBuilder()
-                  .command("git", "clone", GITHUB_URL + booster.getGithubRepo(),
+                  .command("git", "clone", BOOSTER_CATALOG_GIT_HOST + booster.getGithubRepo(),
                            "--branch", booster.getGitRef(),
                            "--recursive",
                            "--depth=1",


### PR DESCRIPTION
As we have with other urls - having it configurable would make it easier for testing (to avoid roundtrips to GH).

I'm open to changing the name and if it should be env variable, system property or both.